### PR TITLE
Fixed bugs in ETS2/ETS3 when displaying prismatic joints

### DIFF
--- a/toolbox/ETS2.m
+++ b/toolbox/ETS2.m
@@ -184,6 +184,14 @@ classdef ETS2
             % parameter is of the form 'qN' and it controls a translation.
             v = isjoint(ets) && (ets.what(1) == 'T');
         end
+
+        function v = isrevolute(ets)
+            %ETS2.isrevolute  Test if transform is revolute joint
+            %
+            % E.isrevolute is true if the transform element is a joint, that is, its
+            % parameter is of the form 'qN' and it controls a rotation.
+            v = isjoint(ets) && (ets.what(1) == 'R');
+        end
         
         function k = find(ets, j)
             %ETS2.find  Find joints in transform sequence
@@ -342,9 +350,6 @@ classdef ETS2
             % ETS.teach(Q, OPTIONS) as above but the robot joint angles are set to Q (1xN).
             %
             % Options::
-            % 'eul'           Display tool orientation in Euler angles (default)
-            % 'rpy'           Display tool orientation in roll/pitch/yaw angles
-            % 'approach'      Display tool orientation as approach vector (z-axis)
             % '[no]deg'       Display angles in degrees (default true)
             %
             % GUI::
@@ -356,6 +361,7 @@ classdef ETS2
             %   set then for
             %   - a revolute joint they are assumed to be [-pi, +pi]
             %   - a prismatic joint they are assumed unknown and an error occurs.
+            % - The tool orientation is expressed using Yaw angle.
             %
             % See also ETS2.plot.
             
@@ -368,7 +374,7 @@ classdef ETS2
             
             %---- handle options
             opt.deg = true;
-            opt.orientation = {'rpy', 'eul', 'approach'};
+            opt.orientation = {'eul', 'rpy', 'approach'};
             opt.d_2d = true;
             opt.callback = [];
             opt.vellipse = false;
@@ -385,16 +391,65 @@ classdef ETS2
             
             if nargin == 1
                 q = zeros(1,robot.n);
+                % Set the default values for prismatic to the mean value 
+                % of its largest and smallest allowed value.
+                for i = 1:length(robot)
+                    e = robot(i);
+                    if isprismatic(e)
+                        q(e.qvar) = mean(e.qlim);
+                    end
+                    % Check if there is an joint angle limit for the
+                    % revolute joint, if so, and the range does not include
+                    % zero, choose the mean value of its largest and
+                    % smallest allowed value. Else, keep 0 as the default.
+                    if isrevolute(e) && ~isempty(e.qlim)
+                        if e.qlim(1) > 0 || e.qlim(2) < 0
+                            q(e.qvar) = mean(e.qlim);
+                        end
+                    end
+                end
             else
                 q = varargin{1};
+                % If the joint parameters are specified, check if the inputs
+                % are legal.
+                for i = 1:length(robot)
+                    e = robot(i);
+                    if isprismatic(e)
+                        if q(e.qvar) < e.qlim(1) || q(e.qvar) > e.qlim(2)
+                            error("Prismatic Joint Parameter Out of Range!")
+                        end
+                        if q(e.qvar) == 0
+                            error("Prismatic Joint Parameter Should Not Be Zero!")
+                            % Set q(e.qvar) to zero will cause 'Matrix'
+                            % property value to be invalid in the scaling
+                            % step of ETS2/animate.
+                        elseif q(e.qvar) < 0
+                            error("Prismatic Joint Parameter Should Not Be Negative!")
+                        end
+                    end
+                    if isrevolute(e)
+                        if ~isempty(e.qlim)
+                            if q(e.qvar) < e.qlim(1) || q(e.qvar) > e.qlim(2)
+                                error("Prismatic Joint Parameter Out of Range!")
+                            end
+                        else    % If qlim not set, use [-pi, +pi]
+                            if q(e.qvar) < -pi || q(e.qvar) > pi
+                                error("Revolute Joint Parameter Out of Range!")
+                            end
+                        end
+                    end
+                end
             end
-            robot.plot(q, args{2:end});
+
+            % Save a copy for the initial q, used for scaling
+            q_initial = q(:,:);
+            robot.plot(q, q_initial, args{2:end});
             
-            RTBPlot.install_teach_panel('ETS2', robot, q, opt);
+            RTBPlot.install_teach_panel('ETS2', robot, q, q_initial, opt);
         end
         
         
-        function plot(ets, qq, varargin)
+        function plot(ets, qq, q_initial, varargin)
             %ETS2.plot Graphical display and animation
             %
             % ETS.plot(Q, options) displays a graphical animation of a robot based on
@@ -543,10 +598,10 @@ classdef ETS2
             % enable mouse-based 3D rotation
             rotate3d on
             
-            ets.animate(qq);
+            ets.animate(qq, q_initial);
         end
         
-        function animate(~, qq)
+        function animate(~, qq, q_initial)
             handles = findobj('Tag', 'ETS2');
             h = handles.UserData;
             opt = h.opt;
@@ -568,11 +623,12 @@ classdef ETS2
                     
                     if isprismatic(e)
                         % for prismatic joints, scale the box
+                        original = q_initial(e.qvar);
                         switch e.what
                             case 'Tx'
-                                set(h.pjoint(e.qvar), 'Matrix', diag([q(e.qvar) 1 1 1]));
+                                set(h.pjoint(e.qvar), 'Matrix', diag([q(e.qvar)/original 1 1 1]));
                             case 'Ty'
-                                set(h.pjoint(e.qvar), 'Matrix', diag([1 q(e.qvar) 1 1]));
+                                set(h.pjoint(e.qvar), 'Matrix', diag([1 q(e.qvar)/original 1 1]));
                         end
                     end
                 end
@@ -667,11 +723,11 @@ classdef ETS2
                     % it's a joint element: revolute or prismatic
                     switch e.what
                         case 'Tx'
-                            h.pjoint(e.qvar) = hgtransform('Tag', 'prismatic', 'Parent', h.element(i), 'Matrix', diag([q(e.qvar) 1 1 1]));
-                            RTBPlot.box('x', opt.jointdiam*s, [0 1], opt.pjointcolor, [], 'Parent', h.pjoint(i));
+                            h.pjoint(e.qvar) = hgtransform('Tag', 'prismatic', 'Parent', h.element(i), 'Matrix', [1 0 0 q(e.qvar); 0 1 0 0; 0 0 1 0; 0 0 0 1]);
+                            RTBPlot.box('x', opt.jointdiam*s, [0 q(e.qvar)], opt.pjointcolor, [], 'Parent', h.pjoint(e.qvar));
                         case 'Ty'
-                            h.pjoint(e.qvar) = hgtransform('Tag', 'prismatic', 'Parent', h.element(i), 'Matrix', diag([1 q(e.qvar) 1 1]));
-                            RTBPlot.box('y', opt.jointdiam*s, [0 1], opt.pjointcolor, [], 'Parent', h.pjoint(i));
+                            h.pjoint(e.qvar) = hgtransform('Tag', 'prismatic', 'Parent', h.element(i), 'Matrix', [1 0 0 0; 0 1 0 q(e.qvar); 0 0 1 0; 0 0 0 1]);
+                            RTBPlot.box('y', opt.jointdiam*s, [0 q(e.qvar)], opt.pjointcolor, [], 'Parent', h.pjoint(e.qvar));
                         case 'Rz'
                             RTBPlot.cyl('z', opt.jointdiam*s, opt.jointlen*s*[-1 1], opt.jointcolor, [], 'Parent', h.element(i));
                     end


### PR DESCRIPTION
Considering the bugs mentioned in #5, I tried to fix the visualization problems of the prismatic joints in the teach methods of both ETS2 and ETS3. The related file RTBPlot is also modified.

I also added improved handling and validation for prismatic and revolute joint limits in ETS2 and ETS3 teach and plot methods. The teach panel now uses correct joint limits and scaling, and prismatic joint visualization is updated to reflect actual joint values.  Correspondingly, RTBPlot is updated to support new teach panel arguments and correct joint scaling.

Whether this change will affect other parts of the toolbox still needs further confirmation.